### PR TITLE
style(Navs): 下拉导航栏颜色适配暗色模式

### DIFF
--- a/frontend/components/Navs/index.vue
+++ b/frontend/components/Navs/index.vue
@@ -53,7 +53,7 @@ const isNavShown = inject('isNavShown')
 
 .nav-item-wrapper{
   @apply hidden md:(flex h-full);
-  @apply lt-md:(absolute top-4rem left-2rem p-2 h-auto border-1 border-jj-navs-wrapper-normal rounded-md shadow-xl shadow-black/10 dark:shadow-white/10 transform-gpu -translate-x-1/2 bg-jj-navs-background-normal);
+  @apply lt-md:(absolute top-4rem left-2rem p-2 h-auto border-1 border-jj-navs-wrapper-normal rounded-md shadow-xl shadow-black/10 dark:shadow-white/10 transform-gpu -translate-x-1/2 bg-jj-article);
 }
 .mobile-nav{
   @apply f-c-c md:hidden text-jj-blue-normal;


### PR DESCRIPTION
浏览器缩小状态下点击首页展示的下拉导航栏的颜色改为灰色，原来搞的时候给这个地方漏了