### PR TITLE
Issue 295 文章列表没有数据时不触底更新

### DIFF
--- a/frontend/components/ArticlesList/index.vue
+++ b/frontend/components/ArticlesList/index.vue
@@ -10,7 +10,7 @@ const addArtListItem = useThrottle(async () => {
 })
 provide('artlist', artlist)
 provide('ads', articleAds)
-watch(route, async () => {
+watch([() => route.query, () => route.params], async () => {
   isLoading.value = true
   artlist.value = await useFetchPostData(route?.params, route.query?.sort, pagenum = 1)
   isLoading.value = false

--- a/frontend/components/ArticlesList/index.vue
+++ b/frontend/components/ArticlesList/index.vue
@@ -6,7 +6,7 @@ const isLoading = useState('isLoading', () => false)
 const route = useRoute()
 let pagenum = 1
 const addArtListItem = useThrottle(async () => {
-  useScrollBottom() && artlist.value.push(...(await useFetchPostData(route?.params, route.query?.sort, ++pagenum)))
+  useScrollBottom() && artlist.value?.length && artlist.value.push(...(await useFetchPostData(route?.params, route.query?.sort, ++pagenum)))
 })
 provide('artlist', artlist)
 provide('ads', articleAds)


### PR DESCRIPTION
当不存在文章列表内容时，滑动到底部不会请求数据

试着修复一下build之后刷新页面，路由请求参数不起作用的问题